### PR TITLE
ProfilerReporterImpl registered in profiler before it's fully initialized

### DIFF
--- a/commons-profiler-api/src/main/java/ru/fix/commons/profiler/impl/ProfilerReporterImpl.java
+++ b/commons-profiler-api/src/main/java/ru/fix/commons/profiler/impl/ProfilerReporterImpl.java
@@ -44,10 +44,11 @@ class ProfilerReporterImpl implements ProfilerReporter {
                                 boolean enableActiveCallsMaxLatency,
                                 int numberOfActiveCallsToKeepBetweenReports) {
         this.profiler = profiler;
-        this.profiler.registerReporter(this);
         this.enableActiveCallsMaxLatency = new AtomicBoolean(enableActiveCallsMaxLatency);
         this.numberOfActiveCallsToKeepBetweenReports = new AtomicInteger(numberOfActiveCallsToKeepBetweenReports);
         lastReportTimestamp = new AtomicLong(System.currentTimeMillis());
+
+        this.profiler.registerReporter(this);
     }
 
     @Override


### PR DESCRIPTION
Caused NPE:
```
java.lang.NullPointerException: null
	at ru.fix.commons.profiler.impl.ProfilerReporterImpl.lambda$applyToSharedCounters$1(ProfilerReporterImpl.java:73)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	at ru.fix.commons.profiler.impl.ProfilerReporterImpl.applyToSharedCounters(ProfilerReporterImpl.java:72)
	at ru.fix.commons.profiler.impl.SimpleProfiler.lambda$applyToSharedCounters$0(SimpleProfiler.java:49)
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:890)
	at ru.fix.commons.profiler.impl.SimpleProfiler.applyToSharedCounters(SimpleProfiler.java:49)
	at ru.fix.commons.profiler.impl.ProfiledCallImpl.start(ProfiledCallImpl.java:43)
```